### PR TITLE
Pin developer package requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # At the time of writing this pypy3.10 is not available through setup-python
-        python-version: [3.7, 3.8, 3.9, "3.10", pypy3.7, pypy3.8, pypy3.9]
+        python-version: [3.8, 3.9, "3.10", pypy3.8, pypy3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ IP addresses of the computer. It is tested on **Linux**, **OS X**, and
 **Solaris/Illumos** should also work.
 
 This library is open source and released under the MIT License. It works
-with Python 3.7+.
+with Python 3.8+.
 
 You can install it with `pip install ifaddr`. It doesn't need to
 compile anything, so there shouldn't be any surprises. Even on Windows.
@@ -85,6 +85,13 @@ property.  For example:
 ---------
 Changelog
 ---------
+
+Not released yet
+----------------
+
+Removed:
+
+* Dropped Python 3.7 support
 
 0.2.0
 -----

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-black;implementation_name=="cpython"
-mypy;implementation_name=="cpython"
+black==22.3.0;implementation_name=="cpython"
+mypy==0.961;implementation_name=="cpython"
 # netifaces only provides 64-bit Windows wheels for Python 3.6 and 3.7 and we use 64-bit CI builds
 netifaces;python_version=='3.7' and platform_system=='Windows' or platform_system!='Windows'
-pytest
-pytest-cov
+pytest==7.1.2
+pytest-cov==3.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black;implementation_name=="cpython"
 mypy;implementation_name=="cpython"
-# netifaces only provides 64-bit Windows wheels for Python 3.6 and 3.7 and we use 64-bit CI builds
-netifaces;python_version=='3.7' and platform_system=='Windows' or platform_system!='Windows'
+# netifaces only provides 64-bit Windows wheels for Python up to 3.8 and we use 64-bit CI builds
+netifaces;python_version=='3.8' and platform_system=='Windows' or platform_system!='Windows'
 pytest
 pytest-cov


### PR DESCRIPTION
Make CI green by pinning all development dependencies to versions which have been current at the time of the last release (0.2.0). This gives a starting point to update dev requirements along with the code base.